### PR TITLE
Add test for custom fieldName

### DIFF
--- a/src/main/scala/benc/BDecoder.scala
+++ b/src/main/scala/benc/BDecoder.scala
@@ -104,11 +104,12 @@ object BDecoder {
 
   implicit def hlistDecoder[K <: Symbol, H, T <: HList](
       implicit
+      fn: FieldName,
       witness: Witness.Aux[K],
       henc: Lazy[BDecoder[H]],
       tenc: BMapDecoder[T]
   ): BMapDecoder[FieldType[K, H] :: T] = {
-    val name = witness.value.name
+    val name = fn.name(witness.value)
     bmapDInstance { bmap =>
       val value: Result[H] = (bmap.m.get(name), henc.value) match {
         case (None, _: OptionBDecoder[_]) =>

--- a/src/main/scala/benc/BEncoder.scala
+++ b/src/main/scala/benc/BEncoder.scala
@@ -82,11 +82,12 @@ object BEncoder {
 
   implicit def hlistEncoder[K <: Symbol, H, T <: HList](
       implicit
+      fieldName: FieldName,
       witness: Witness.Aux[K],
       henc: Lazy[BEncoder[H]],
       tenc: BMapEncoder[T]
   ): BMapEncoder[FieldType[K, H] :: T] = {
-    val name = witness.value.name
+    val name = fieldName.name(witness.value)
     bmapInstance { v =>
       val value: Result[Map[String, BType]] =
         (henc.value.encode(v.head), henc.value) match {

--- a/src/main/scala/benc/FieldName.scala
+++ b/src/main/scala/benc/FieldName.scala
@@ -1,0 +1,13 @@
+package benc
+
+trait FieldName {
+  def name[K <: Symbol](k: K): String
+}
+
+object FieldName {
+
+  implicit object defaultFieldName extends FieldName {
+    override def name[K <: Symbol](k: K): String = k.name
+  }
+
+}


### PR DESCRIPTION
FieldName allows to set naming strategy for filed names during decoding and encoding   